### PR TITLE
Add rate limiting to external HTTP requests

### DIFF
--- a/flock.py
+++ b/flock.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import os
 import HTMLParser
 import urllib
+import urllib2
 import urlparse
 import logging
 import json
@@ -19,8 +20,17 @@ cache = MemcachedCache(['127.0.0.1:11211'])
 
 logging.getLogger().setLevel(logging.DEBUG)
 
-REDDIT_URL = 'www.reddit.com'
+REDDIT_URL = 'http://www.reddit.com'
 USER_AGENT = 'flock/0.1 by /u/rblstr'
+
+
+def makeRequest(url):
+    headers = {
+        'User-Agent': USER_AGENT
+    }
+    request = urllib2.Request(url, headers=headers)
+    return urllib2.urlopen(request)
+
 
 rate_limited_requests = {}
 
@@ -32,41 +42,44 @@ def rateLimitedRequest(url, timeout):
     delta = request_time - last_request_time
     if delta.seconds < timeout:
         time.sleep(timeout-delta.seconds)
-    response = urllib.urlopen(url)
+    response = makeRequest(url)
     request_time = datetime.now()
     rate_limited_requests[url] = request_time
     return response
 
 
 def getRedditResponse(subreddits, sort='top', t='week', limit=100):
-    connection = httplib.HTTPConnection(REDDIT_URL)
-
     query = {
-        't' : t,
-        'limit' : limit
+        't': t,
+        'limit': limit
     }
     query_string = urllib.urlencode(query)
-    
-    request_url = '/r/%s/%s.json?%s' % ('+'.join(subreddits), sort, query_string)
-    
-    headers = {
-        'User-Agent' : USER_AGENT
-    }
-    
-    connection.request('GET', request_url, headers=headers)
-    response = connection.getresponse()
 
-    if not response or response.status != 200:
+    request_url = '%s/r/%s/%s.json?%s' % (REDDIT_URL,
+                                          '+'.join(subreddits),
+                                          sort,
+                                          query_string)
+
+    headers = {
+        'User-Agent': USER_AGENT
+    }
+
+    try:
+        response = rateLimitedRequest(request_url, 2.0)
+    except urllib2.HTTPError:
         return None
-    
+
+    if not response:
+        return None
+
     body = response.read()
     try:
         response_object = json.loads(body)
     except ValueError:
         return None
-    if response_object.get('error') != None:
+    if response_object.get('error') is not None:
         return None
-    
+
     return response_object
 
 
@@ -129,10 +142,10 @@ def parseChild(child):
 def parseRedditResponse(response_object):
     response_copy = copy.deepcopy(response_object)
     html_parser = HTMLParser.HTMLParser()
-    
+
     children = response_copy['data']['children']
     children = [child['data'] for child in children]
-    
+
     links = []
     for child in children:
         url = sanitiseURL(child.get('url'))
@@ -140,10 +153,11 @@ def parseRedditResponse(response_object):
             continue
         child['url'] = url
         child['title'] = html_parser.unescape(child.get('title'))
-        child['permalink'] = 'http://%s%s' % (REDDIT_URL, child.get('permalink'))
+        child['permalink'] = 'http://%s%s' % (REDDIT_URL,
+                                              child.get('permalink'))
         child = parseChild(child)
         links.append(child)
-        
+
     return links
 
 
@@ -166,22 +180,23 @@ def generateYouTubeURL(links):
             continue
         v_id = v_id[0]
         youtube_ids.append(v_id)
-        
+
     first_id = youtube_ids[0]
     youtube_ids = youtube_ids[1:]
     playlist = ",".join(youtube_ids)
     playlist = unicode(playlist).encode('utf-8')
 
     query = {
-        'autohide' : 0,
-        'showinfo' : 1,
-        'modestbranding' : 1,
-        'rel' : 0,
-        'playlist' : playlist
+        'autohide': 0,
+        'showinfo': 1,
+        'modestbranding': 1,
+        'rel': 0,
+        'playlist': playlist
     }
     query_string = urllib.urlencode(query)
-    
-    youtube_url = "https://www.youtube.com/embed/%s?%s" % (first_id, query_string)
+
+    youtube_url = "https://www.youtube.com/embed/%s?%s" % (first_id,
+                                                           query_string)
     return youtube_url
 
 
@@ -205,8 +220,9 @@ def getLinks(subreddits, sort, t):
         response_links = parseRedditResponse(reddit_response)
 
         for subreddit in subreddits_to_get:
-            subreddit_links = filter(lambda link: link.get('subreddits') != subreddit,
-                                        response_links)
+            subreddit_links = filter(lambda link:
+                                     link.get('subreddits') != subreddit,
+                                     response_links)
             if subreddit_links:
                 key = "%s+%s+%s" % (subreddit, sort, t)
                 cache.set(key, pickle.dumps(subreddit_links))
@@ -237,8 +253,8 @@ def top(entry):
 
 
 supported_sorts = {
-    'top' : top,
-    'hot' : hot
+    'top': top,
+    'hot': hot
 }
 
 supported_times = [
@@ -277,7 +293,7 @@ def playlist():
         return redirect('/')
 
     subreddits = subreddits_str.split()
-    
+
     links = getLinks(subreddits, sort, t)
 
     if not links:
@@ -294,12 +310,12 @@ def playlist():
 
     youtube_url = generateYouTubeURL(links)
 
-    return render_template( 'front.html',
-                            subreddits=subreddits_str,
-                            youtube_url=youtube_url,
-                            links=links, 
-                            sort=sort,
-                            time=t)
+    return render_template('front.html',
+                           subreddits=subreddits_str,
+                           youtube_url=youtube_url,
+                           links=links,
+                           sort=sort,
+                           time=t)
 
 
 app.config.from_object('debug_config')
@@ -309,4 +325,3 @@ if os.getenv('FLOCK_SETTINGS', None):
 
 if __name__ == '__main__':
     app.run(debug=True)
-

--- a/tests.py
+++ b/tests.py
@@ -7,581 +7,575 @@ import unittest
 import mock
 import flock
 import io
-import urllib
+import urllib2
 import datetime
 
 
 class MockHTTPResponseWithString(object):
-	def __init__(self, status, response):
-		self.status = status
-		self.response = response
-	
-	def read(self):
-		return self.response
+    def __init__(self, status, response):
+        self.status = status
+        self.response = response
+    
+    def read(self):
+        return self.response
 
 
 class FlockBaseTestCase(unittest.TestCase):
-	def setUp(self):
-		flock.app.testing = True
-		self.app = flock.app.test_client()
-		
-		test_json_handle = open('tests/futuregarage_top_week_100.json')
-		self.futuregarage_top = json.load(test_json_handle)
-		test_json_handle.close()
+    def setUp(self):
+        flock.app.testing = True
+        self.app = flock.app.test_client()
+        
+        test_json_handle = open('tests/futuregarage_top_week_100.json')
+        self.futuregarage_top = json.load(test_json_handle)
+        test_json_handle.close()
 
-		test_json_handle = open('tests/futuregarage_hot_week_100.json')
-		self.futuregarage_hot = json.load(test_json_handle)
-		test_json_handle.close()
+        test_json_handle = open('tests/futuregarage_hot_week_100.json')
+        self.futuregarage_hot = json.load(test_json_handle)
+        test_json_handle.close()
 
-		self.original_getRedditResponse = flock.getRedditResponse
-		self.original_cache_get = flock.cache.get
-		self.original_cache_set = flock.cache.set
-		self.original_request = flock.httplib.HTTPConnection.request
-		self.original_response = flock.httplib.HTTPConnection.getresponse
+        self.original_getRedditResponse = flock.getRedditResponse
+        self.original_cache_get = flock.cache.get
+        self.original_cache_set = flock.cache.set
+        self.original_urlopen = flock.urllib2.urlopen
 
-		""" We never want to make an actual HTTP request """
-		flock.httplib.HTTPConnection.request = mock.MagicMock(name='request')
-		""" Ensure we don't hit the cache by default """
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
-	
-	def tearDown(self):
-		flock.getRedditResponse = self.original_getRedditResponse
-		flock.cache.get = self.original_cache_get
-		flock.cache.set = self.original_cache_set
-		flock.httplib.HTTPConnection.request = self.original_request
-		flock.httplib.HTTPConnection.getresponse = self.original_response
+        """ We never want to make an actual HTTP request """
+        flock.urllib2.urlopen = mock.MagicMock()
+        """ Ensure we don't hit the cache by default """
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
+    
+    def tearDown(self):
+        flock.getRedditResponse = self.original_getRedditResponse
+        flock.cache.get = self.original_cache_get
+        flock.cache.set = self.original_cache_set
+        flock.urllib2.urlopen = self.original_urlopen
+
+        flock.rate_limited_requests = {}
 
 
 class FrontpageTestCase(FlockBaseTestCase):
-	def test_frontpage(self):
-		response = self.app.get('/', content_type='text/html', follow_redirects=True)
-		self.assertEqual(response.status_code, 200)
+    def test_frontpage(self):
+        response = self.app.get('/', content_type='text/html', follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
 
-	def test_frontpage_subreddits_no_response(self):
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(name='getresponse',
-																  return_value=None)
+    def test_frontpage_subreddits_no_response(self):
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.urllib2.urlopen = mock.MagicMock(return_value=None)
 
-		response = self.app.get('/?subreddits=futuregarage',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertIn('No Reddit response', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('No Reddit response', response.data)
 
-	def test_frontpage_subreddits_no_response_404(self):
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(name='getresponse',
-												return_value=MockHTTPResponseWithString(404, ''))
+    def test_frontpage_subreddits_no_response_404(self):
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        def throw_404(url):
+            raise urllib2.HTTPError(url, 404, 'Not found', None, None)
+        flock.urllib2.urlopen = mock.MagicMock(side_effect=throw_404)
 
-		response = self.app.get('/?subreddits=futuregarage',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertIn('No Reddit response', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('No Reddit response', response.data)
 
-	def test_frontpage_subreddits_reddit_error(self):
-		response_string = '{ "error" : {} }'
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(name='getresponse',
-									return_value=MockHTTPResponseWithString(200, response_string))
+    def test_frontpage_subreddits_reddit_error(self):
+        response_string = u'{ "error" : {} }'
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.urllib2.urlopen = mock.MagicMock(return_value=io.StringIO(response_string))
 
-		response = self.app.get('/?subreddits=futuregarage',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertIn('No Reddit response', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('No Reddit response', response.data)
 
-	def test_frontpage_subreddits_invalid_json(self):
-		response_string = '<html></html>'
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(name='getresponse',
-									return_value=MockHTTPResponseWithString(200, response_string))
+    def test_frontpage_subreddits_invalid_json(self):
+        return_value = io.StringIO(u'<html></html>')
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.urllib2.urlopen = mock.MagicMock(return_value=return_value)
 
-		response = self.app.get('/?subreddits=futuregarage',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertIn('No Reddit response', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('No Reddit response', response.data)
 
-	def test_frontpage_subreddits_no_youtube_links(self):
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(
-				name='getresponse',
-				return_value=MockHTTPResponseWithString(200, json.dumps(self.futuregarage_top)))
+    def test_frontpage_subreddits_no_youtube_links(self):
+        return_value = io.StringIO(json.dumps(self.futuregarage_top, ensure_ascii=False))
+        flock.urllib2.urlopen = mock.MagicMock(return_value=return_value)
 
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		response = self.app.get('/?subreddits=futuregarage',
-				                content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-		for child in self.futuregarage_top['data']['children']:
-			child = child['data']
-			if not 'youtube' in child['domain'] and not 'youtu.be' in child['domain']:
-				self.assertNotIn(child['title'], response.data)
+        for child in self.futuregarage_top['data']['children']:
+            child = child['data']
+            if not 'youtube' in child['domain'] and not 'youtu.be' in child['domain']:
+                self.assertNotIn(child['title'], response.data)
 
-	def test_parse_reddit_response(self):
-		futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
-		futuregarage_links = [ child['title'] for child in futuregarage_links ]
-		for child in self.futuregarage_top['data']['children']:
-			child = child['data']
-			if not 'youtube' in child['domain'] and not 'youtu.be' in child['domain']:
-				self.assertNotIn(child['title'], futuregarage_links)
+    def test_parse_reddit_response(self):
+        futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
+        futuregarage_links = [ child['title'] for child in futuregarage_links ]
+        for child in self.futuregarage_top['data']['children']:
+            child = child['data']
+            if not 'youtube' in child['domain'] and not 'youtu.be' in child['domain']:
+                self.assertNotIn(child['title'], futuregarage_links)
 
-	def test_frontpage_subreddits_all_links_present(self):
-		h = HTMLParser.HTMLParser()
-		futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
+    def test_frontpage_subreddits_all_links_present(self):
+        h = HTMLParser.HTMLParser()
+        futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
 
-		flock.httplib.HTTPConnection.request = mock.MagicMock(name='request')
-		flock.httplib.HTTPConnection.getresponse = mock.MagicMock(
-				name='getresponse ',
-				return_value=MockHTTPResponseWithString(200, json.dumps(self.futuregarage_top)))
-	
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        return_value = io.StringIO(json.dumps(self.futuregarage_top, ensure_ascii=False))
+        flock.urllib2.urlopen = mock.MagicMock(return_value=return_value)
+    
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		response = self.app.get('/?subreddits=futuregarage',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-		unescaped_response = h.unescape(response.data)
-		for child in futuregarage_links:
-			self.assertIn(child['title'], unescaped_response)
-			self.assertIn(child['url'], unescaped_response)
-			self.assertIn(child['permalink'], unescaped_response)
+        unescaped_response = h.unescape(response.data)
+        for child in futuregarage_links:
+            self.assertIn(child['title'], unescaped_response)
+            self.assertIn(child['url'], unescaped_response)
+            self.assertIn(child['permalink'], unescaped_response)
 
 class SanitiseURLCase(unittest.TestCase):
-	def test_sanitise_short_youtube_url(self):
-		url = 'http://youtu.be/wRpHf4X7FNM'
-		new_url = flock.sanitiseShortYouTubeURL(url)
-		self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
+    def test_sanitise_short_youtube_url(self):
+        url = 'http://youtu.be/wRpHf4X7FNM'
+        new_url = flock.sanitiseShortYouTubeURL(url)
+        self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
 
-	def test_sanitise_short_youtube_url_fail_long(self):
-		url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-		new_url = flock.sanitiseShortYouTubeURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_short_youtube_url_fail_long(self):
+        url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+        new_url = flock.sanitiseShortYouTubeURL(url)
+        self.assertEquals(new_url, None)
 
-	def test_sanitise_short_youtube_url_fail_wrong(self):
-		url = 'http://i.imgur.com/2A2IS5z.jpg'
-		new_url = flock.sanitiseShortYouTubeURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_short_youtube_url_fail_wrong(self):
+        url = 'http://i.imgur.com/2A2IS5z.jpg'
+        new_url = flock.sanitiseShortYouTubeURL(url)
+        self.assertEquals(new_url, None)
 
-	def test_sanitise_short_youtube_url_fail_no_videoid(self):
-		url = 'http://youtu.be/'
-		new_url = flock.sanitiseShortYouTubeURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_short_youtube_url_fail_no_videoid(self):
+        url = 'http://youtu.be/'
+        new_url = flock.sanitiseShortYouTubeURL(url)
+        self.assertEquals(new_url, None)
 
-	def test_sanitise_long_youtube_url(self):
-		url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-		new_url = flock.sanitiseYouTubeURL(url)
-		self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
+    def test_sanitise_long_youtube_url(self):
+        url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+        new_url = flock.sanitiseYouTubeURL(url)
+        self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
 
-	def test_sanitise_long_youtube_url_fail_short(self):
-		url = 'http://youtu.be/wRpHf4X7FNM'
-		new_url = flock.sanitiseYouTubeURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_long_youtube_url_fail_short(self):
+        url = 'http://youtu.be/wRpHf4X7FNM'
+        new_url = flock.sanitiseYouTubeURL(url)
+        self.assertEquals(new_url, None)
 
-	def test_sanitise_long_youtube_url_fail_wrong(self):
-		url = 'http://i.imgur.com/2A2IS5z.jpg'
-		new_url = flock.sanitiseYouTubeURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_long_youtube_url_fail_wrong(self):
+        url = 'http://i.imgur.com/2A2IS5z.jpg'
+        new_url = flock.sanitiseYouTubeURL(url)
+        self.assertEquals(new_url, None)
 
-	def test_sanitise_youtube_url_short_input(self):
-		url = 'http://youtu.be/wRpHf4X7FNM'
-		new_url = flock.sanitiseURL(url)
-		self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
+    def test_sanitise_youtube_url_short_input(self):
+        url = 'http://youtu.be/wRpHf4X7FNM'
+        new_url = flock.sanitiseURL(url)
+        self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
 
-	def test_sanitise_youtube_url_long_input(self):
-		url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-		new_url = flock.sanitiseURL(url)
-		self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
+    def test_sanitise_youtube_url_long_input(self):
+        url = 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+        new_url = flock.sanitiseURL(url)
+        self.assertEquals(new_url, 'http://www.youtube.com/watch?v=wRpHf4X7FNM')
 
-	def test_sanitise_youtube_url_fail(self):
-		url = 'http://i.imgur.com/2A2IS5z.jpg'
-		new_url = flock.sanitiseURL(url)
-		self.assertEquals(new_url, None)
+    def test_sanitise_youtube_url_fail(self):
+        url = 'http://i.imgur.com/2A2IS5z.jpg'
+        new_url = flock.sanitiseURL(url)
+        self.assertEquals(new_url, None)
 
 class YouTubeEmbedURLTestCase(unittest.TestCase):
-	def test_generate_youtube_embed_url_one_link(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		youtube_url = flock.generateYouTubeURL(links)
-		expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=&showinfo=1&autohide=0&rel=0'
-		self.assertEquals(youtube_url, expected)
+    def test_generate_youtube_embed_url_one_link(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        youtube_url = flock.generateYouTubeURL(links)
+        expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=&showinfo=1&autohide=0&rel=0'
+        self.assertEquals(youtube_url, expected)
 
-	def test_generate_youtube_embed_url_two_links(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		youtube_url = flock.generateYouTubeURL(links)
-		expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
-		self.assertEquals(youtube_url, expected)
+    def test_generate_youtube_embed_url_two_links(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        youtube_url = flock.generateYouTubeURL(links)
+        expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
+        self.assertEquals(youtube_url, expected)
 
-	def test_generate_youtube_embed_url_multiple_links(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		youtube_url = flock.generateYouTubeURL(links)
-		expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM%2CwRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
-		self.assertEquals(youtube_url, expected)
+    def test_generate_youtube_embed_url_multiple_links(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        youtube_url = flock.generateYouTubeURL(links)
+        expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM%2CwRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
+        self.assertEquals(youtube_url, expected)
 
-	def test_generate_youtube_embed_url_missing_videoid(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/v/wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		youtube_url = flock.generateYouTubeURL(links)
-		expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
-		self.assertEquals(youtube_url, expected)
+    def test_generate_youtube_embed_url_missing_videoid(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/v/wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        youtube_url = flock.generateYouTubeURL(links)
+        expected = 'https://www.youtube.com/embed/wRpHf4X7FNM?modestbranding=1&playlist=wRpHf4X7FNM&showinfo=1&autohide=0&rel=0'
+        self.assertEquals(youtube_url, expected)
 
 
 class DuplicatesTestCase(unittest.TestCase):
-	def test_remove_duplicates_one_link(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		new_links = flock.removeDuplicates(links)
-		self.assertEquals(new_links, links)
+    def test_remove_duplicates_one_link(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        new_links = flock.removeDuplicates(links)
+        self.assertEquals(new_links, links)
 
-	def test_remove_duplicates_duplicate_links(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					}
-				]
-		new_links = flock.removeDuplicates(links)
-		del links[1]
-		self.assertEquals(new_links, links)
+    def test_remove_duplicates_duplicate_links(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    }
+                ]
+        new_links = flock.removeDuplicates(links)
+        del links[1]
+        self.assertEquals(new_links, links)
 
-	def test_remove_duplicates_non_duplicate_links(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=eAUaOTLvBIM'
-					}
-				]
-		new_links = flock.removeDuplicates(links)
-		self.assertEquals(new_links, links)
+    def test_remove_duplicates_non_duplicate_links(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=eAUaOTLvBIM'
+                    }
+                ]
+        new_links = flock.removeDuplicates(links)
+        self.assertEquals(new_links, links)
 
-	def test_remove_duplicates_duplicate_links_order_preserved(self):
-		links = [
-				{
-					'url' : 'http://www.youtube.com/watch?v=AY08MWIGYsk'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
-					},
-				{
-					'url' : 'http://www.youtube.com/watch?v=cfLmW-dKtwg'
-					}
-				]
-		new_links = flock.removeDuplicates(links)
-		del links[2]
-		self.assertEquals(new_links, links)
+    def test_remove_duplicates_duplicate_links_order_preserved(self):
+        links = [
+                {
+                    'url' : 'http://www.youtube.com/watch?v=AY08MWIGYsk'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=wRpHf4X7FNM'
+                    },
+                {
+                    'url' : 'http://www.youtube.com/watch?v=cfLmW-dKtwg'
+                    }
+                ]
+        new_links = flock.removeDuplicates(links)
+        del links[2]
+        self.assertEquals(new_links, links)
 
 
 class OptionalPlaylistOptionsTestCase(FlockBaseTestCase):
-	def test_accepts_valid_optional_arguments(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_accepts_valid_optional_arguments(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&sort=hot&t=month&limit=50',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&sort=hot&t=month&limit=50',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'month', 100)
-		self.assertEqual(response.status_code, 200)
+        flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'month', 100)
+        self.assertEqual(response.status_code, 200)
 
-	def test_limit_argument_operates_on_reddit_results_post_parsing(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_limit_argument_operates_on_reddit_results_post_parsing(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&sort=hot&t=month&limit=2',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&sort=hot&t=month&limit=2',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'month', 100)
-		self.assertEqual(response.data.count('"track"'), 2)
+        self.assertEqual(response.status_code, 200)
+        flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'month', 100)
+        self.assertEqual(response.data.count('"track"'), 2)
 
-	def test_unsupported_sort_argument(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_unsupported_sort_argument(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&sort=error',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&sort=error',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertFalse(flock.getRedditResponse.called)
-		self.assertIn('Invalid sort type: error', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(flock.getRedditResponse.called)
+        self.assertIn('Invalid sort type: error', response.data)
 
-	def test_unsupported_time_argument(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_unsupported_time_argument(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&t=never',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&t=never',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertFalse(flock.getRedditResponse.called)
-		self.assertIn('Invalid time type: never', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(flock.getRedditResponse.called)
+        self.assertIn('Invalid time type: never', response.data)
 
-	def test_unsupported_limit_argument(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_unsupported_limit_argument(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&limit=1000',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&limit=1000',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertFalse(flock.getRedditResponse.called)
-		self.assertIn('Invalid limit: 1000', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(flock.getRedditResponse.called)
+        self.assertIn('Invalid limit: 1000', response.data)
 
-	def test_unsupported_limit_string_argument(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_unsupported_limit_string_argument(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		response = self.app.get('/?subreddits=futuregarage&limit=never',
-								content_type='text/html',
-								follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage&limit=never',
+                                content_type='text/html',
+                                follow_redirects=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertFalse(flock.getRedditResponse.called)
-		self.assertTrue('Invalid limit: never', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(flock.getRedditResponse.called)
+        self.assertTrue('Invalid limit: never', response.data)
 
 
 class CacheTestCase(FlockBaseTestCase):
-	def test_frontpage_hits_memcached(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',				
-												 return_value=self.futuregarage_top)
+    def test_frontpage_hits_memcached(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',              
+                                                 return_value=self.futuregarage_top)
 
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		response = self.app.get('/?subreddits=futuregarage', follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage', follow_redirects=True)
 
-		self.assertEquals(response.status_code, 200)
-		flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'week', 100)
-		flock.cache.get.assert_called_once_with('futuregarage+hot+week')
+        self.assertEquals(response.status_code, 200)
+        flock.getRedditResponse.assert_called_once_with(['futuregarage'], 'hot', 'week', 100)
+        flock.cache.get.assert_called_once_with('futuregarage+hot+week')
 
-	def test_frontpage_hits_memcached_same_number_of_times_as_subreddits(self):
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+    def test_frontpage_hits_memcached_same_number_of_times_as_subreddits(self):
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		response = self.app.get('/?subreddits=1+2+3+4+5', follow_redirects=True)
+        response = self.app.get('/?subreddits=1+2+3+4+5', follow_redirects=True)
 
-		self.assertEquals(response.status_code, 200)
-		flock.getRedditResponse.assert_called_once_with(['1', '2', '3', '4', '5'], 'hot', 'week', 100)
-		self.assertEquals(flock.cache.get.call_count, 5)
+        self.assertEquals(response.status_code, 200)
+        flock.getRedditResponse.assert_called_once_with(['1', '2', '3', '4', '5'], 'hot', 'week', 100)
+        self.assertEquals(flock.cache.get.call_count, 5)
 
 
-	def test_frontpage_hits_memcached_same_number_of_times_as_subreddits_with_names(self):
-		return_value = flock.parseRedditResponse(self.futuregarage_top)
+    def test_frontpage_hits_memcached_same_number_of_times_as_subreddits_with_names(self):
+        return_value = flock.parseRedditResponse(self.futuregarage_top)
 
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse', return_value=None)
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse', return_value=None)
 
-		flock.cache.get = mock.MagicMock(name='get', return_value=pickle.dumps(return_value))
+        flock.cache.get = mock.MagicMock(name='get', return_value=pickle.dumps(return_value))
 
-		response = self.app.get('/?subreddits=1+2+3+4+5', follow_redirects=True)
+        response = self.app.get('/?subreddits=1+2+3+4+5', follow_redirects=True)
 
-		self.assertEquals(response.status_code, 200)
-		self.assertFalse(flock.getRedditResponse.called)
-		calls = [ mock.call('1+hot+week'), 
-				mock.call('2+hot+week'),
-				mock.call('3+hot+week'),
-				mock.call('4+hot+week'),
-				mock.call('5+hot+week') ]
-		flock.cache.get.assert_has_calls(calls)
-	
-	def test_link_sort_order_is_maintained_top(self):
-		h = HTMLParser.HTMLParser()
-		futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
-		futuregarage_links = sorted(futuregarage_links,
-									reverse=True,
-									key=lambda l: l['created_utc'])
-		futuregarage_links = sorted(futuregarage_links,
-									reverse=True,
-									key=lambda l: flock.top(l))
+        self.assertEquals(response.status_code, 200)
+        self.assertFalse(flock.getRedditResponse.called)
+        calls = [ mock.call('1+hot+week'), 
+                mock.call('2+hot+week'),
+                mock.call('3+hot+week'),
+                mock.call('4+hot+week'),
+                mock.call('5+hot+week') ]
+        flock.cache.get.assert_has_calls(calls)
+    
+    def test_link_sort_order_is_maintained_top(self):
+        h = HTMLParser.HTMLParser()
+        futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
+        futuregarage_links = sorted(futuregarage_links,
+                                    reverse=True,
+                                    key=lambda l: l['created_utc'])
+        futuregarage_links = sorted(futuregarage_links,
+                                    reverse=True,
+                                    key=lambda l: flock.top(l))
 
-		cache_value = {}
-		cache_value['data'] = {}
-		cache_value['data']['children'] = {}
-		cache_value['data']['children'] = self.futuregarage_top['data']['children'][::2]
-		cache_value = flock.parseRedditResponse(cache_value)
+        cache_value = {}
+        cache_value['data'] = {}
+        cache_value['data']['children'] = {}
+        cache_value['data']['children'] = self.futuregarage_top['data']['children'][::2]
+        cache_value = flock.parseRedditResponse(cache_value)
 
-		def cache_side_effect(*args, **kwargs):
-			if args[0] == 'futuregarage+top+week':
-				return pickle.dumps(cache_value)
-			return None
+        def cache_side_effect(*args, **kwargs):
+            if args[0] == 'futuregarage+top+week':
+                return pickle.dumps(cache_value)
+            return None
 
-		flock.cache.get = mock.MagicMock(name='get')
-		flock.cache.get.side_effect = cache_side_effect
-		
-		reddit_value = {}
-		reddit_value['data'] = {}
-		reddit_value['data']['children'] = {}
-		reddit_value['data']['children'] = self.futuregarage_top['data']['children'][1::2]
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=reddit_value)
+        flock.cache.get = mock.MagicMock(name='get')
+        flock.cache.get.side_effect = cache_side_effect
+        
+        reddit_value = {}
+        reddit_value['data'] = {}
+        reddit_value['data']['children'] = {}
+        reddit_value['data']['children'] = self.futuregarage_top['data']['children'][1::2]
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=reddit_value)
 
-		response = self.app.get('/?subreddits=futuregarage+futurebeats&sort=top', follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage+futurebeats&sort=top', follow_redirects=True)
 
-		unescaped_response = h.unescape(response.data)
-		for child in futuregarage_links:
-			self.assertIn(child['title'], unescaped_response)
-			self.assertIn(child['url'], unescaped_response)
-			self.assertIn(child['permalink'], unescaped_response)
+        unescaped_response = h.unescape(response.data)
+        for child in futuregarage_links:
+            self.assertIn(child['title'], unescaped_response)
+            self.assertIn(child['url'], unescaped_response)
+            self.assertIn(child['permalink'], unescaped_response)
 
-		j = 1
-		for i,child in enumerate(futuregarage_links):
-			first_child = futuregarage_links[i]
-			second_child = futuregarage_links[j]
-			first_pos = unescaped_response.find(first_child['title'])
-			second_pos = unescaped_response.find(second_child['title'])
-			self.assertLess(first_pos, second_pos,
-				'%s:%d, %s:%d' % (first_child['title'], flock.top(first_child),
-								  second_child['title'], flock.top(second_child)))
-			j = j + 1
-			if j >= len(futuregarage_links):
-				break
+        j = 1
+        for i,child in enumerate(futuregarage_links):
+            first_child = futuregarage_links[i]
+            second_child = futuregarage_links[j]
+            first_pos = unescaped_response.find(first_child['title'])
+            second_pos = unescaped_response.find(second_child['title'])
+            self.assertLess(first_pos, second_pos,
+                '%s:%d, %s:%d' % (first_child['title'], flock.top(first_child),
+                                  second_child['title'], flock.top(second_child)))
+            j = j + 1
+            if j >= len(futuregarage_links):
+                break
 
-	def test_link_sort_order_is_maintained_hot(self):
-		h = HTMLParser.HTMLParser()
-		futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
-		futuregarage_links = sorted(futuregarage_links,
-									reverse=True,
-									key=lambda l: l['created_utc'])
-		futuregarage_links = sorted(futuregarage_links,
-									reverse=True,
-									key=lambda l: flock.hot(l))
+    def test_link_sort_order_is_maintained_hot(self):
+        h = HTMLParser.HTMLParser()
+        futuregarage_links = flock.parseRedditResponse(self.futuregarage_top)
+        futuregarage_links = sorted(futuregarage_links,
+                                    reverse=True,
+                                    key=lambda l: l['created_utc'])
+        futuregarage_links = sorted(futuregarage_links,
+                                    reverse=True,
+                                    key=lambda l: flock.hot(l))
 
-		cache_value = {}
-		cache_value['data'] = {}
-		cache_value['data']['children'] = {}
-		cache_value['data']['children'] = self.futuregarage_top['data']['children'][::2]
-		cache_value = flock.parseRedditResponse(cache_value)
+        cache_value = {}
+        cache_value['data'] = {}
+        cache_value['data']['children'] = {}
+        cache_value['data']['children'] = self.futuregarage_top['data']['children'][::2]
+        cache_value = flock.parseRedditResponse(cache_value)
 
-		def cache_side_effect(*args, **kwargs):
-			if args[0] == 'futuregarage+hot+week':
-				return pickle.dumps(cache_value)
-			return None
+        def cache_side_effect(*args, **kwargs):
+            if args[0] == 'futuregarage+hot+week':
+                return pickle.dumps(cache_value)
+            return None
 
-		flock.cache.get = mock.MagicMock(name='get')
-		flock.cache.get.side_effect = cache_side_effect
-		
-		reddit_value = {}
-		reddit_value['data'] = {}
-		reddit_value['data']['children'] = {}
-		reddit_value['data']['children'] = self.futuregarage_top['data']['children'][1::2]
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=reddit_value)
+        flock.cache.get = mock.MagicMock(name='get')
+        flock.cache.get.side_effect = cache_side_effect
+        
+        reddit_value = {}
+        reddit_value['data'] = {}
+        reddit_value['data']['children'] = {}
+        reddit_value['data']['children'] = self.futuregarage_top['data']['children'][1::2]
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=reddit_value)
 
-		response = self.app.get('/?subreddits=futuregarage+futurebeats&sort=hot', follow_redirects=True)
+        response = self.app.get('/?subreddits=futuregarage+futurebeats&sort=hot', follow_redirects=True)
 
-		unescaped_response = h.unescape(response.data)
-		for child in futuregarage_links:
-			self.assertIn(child['title'], unescaped_response)
-			self.assertIn(child['url'], unescaped_response)
-			self.assertIn(child['permalink'], unescaped_response)
+        unescaped_response = h.unescape(response.data)
+        for child in futuregarage_links:
+            self.assertIn(child['title'], unescaped_response)
+            self.assertIn(child['url'], unescaped_response)
+            self.assertIn(child['permalink'], unescaped_response)
 
-		j = 1
-		for i,child in enumerate(futuregarage_links):
-			first_child = futuregarage_links[i]
-			second_child = futuregarage_links[j]
-			first_pos = unescaped_response.find(first_child['title'])
-			second_pos = unescaped_response.find(second_child['title'])
-			self.assertLess(first_pos, second_pos,
-				'%s:%d, %s:%d' % (first_child['title'], flock.top(first_child),
-								  second_child['title'], flock.top(second_child)))
-			j = j + 1
-			if j >= len(futuregarage_links):
-				break
+        j = 1
+        for i,child in enumerate(futuregarage_links):
+            first_child = futuregarage_links[i]
+            second_child = futuregarage_links[j]
+            first_pos = unescaped_response.find(first_child['title'])
+            second_pos = unescaped_response.find(second_child['title'])
+            self.assertLess(first_pos, second_pos,
+                '%s:%d, %s:%d' % (first_child['title'], flock.top(first_child),
+                                  second_child['title'], flock.top(second_child)))
+            j = j + 1
+            if j >= len(futuregarage_links):
+                break
 
-	def test_cache_is_heated_with_parsed_links(self):
-		cache_value = flock.parseRedditResponse(self.futuregarage_top)
-		
-		flock.cache.set = mock.MagicMock(name='set')
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+    def test_cache_is_heated_with_parsed_links(self):
+        cache_value = flock.parseRedditResponse(self.futuregarage_top)
+        
+        flock.cache.set = mock.MagicMock(name='set')
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		self.app.get('/?subreddits=futuregarage', follow_redirects=True)
+        self.app.get('/?subreddits=futuregarage', follow_redirects=True)
 
-		flock.cache.set.assert_called_with('futuregarage+hot+week', pickle.dumps(cache_value))
+        flock.cache.set.assert_called_with('futuregarage+hot+week', pickle.dumps(cache_value))
 
-	def test_cache_is_hit_after_cache_is_warmed(self):
-		cache_value = flock.parseRedditResponse(self.futuregarage_top)
+    def test_cache_is_hit_after_cache_is_warmed(self):
+        cache_value = flock.parseRedditResponse(self.futuregarage_top)
 
-		flock.cache.set = mock.MagicMock(name='set')
-		flock.cache.get = mock.MagicMock(name='get', return_value=None)
+        flock.cache.set = mock.MagicMock(name='set')
+        flock.cache.get = mock.MagicMock(name='get', return_value=None)
 
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
-												 return_value=self.futuregarage_top)
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse',
+                                                 return_value=self.futuregarage_top)
 
-		self.app.get('/?subreddits=futuregarage', follow_redirects=True)
+        self.app.get('/?subreddits=futuregarage', follow_redirects=True)
 
-		flock.getRedditResponse.assert_called_with(['futuregarage'], 'hot', 'week', 100)
-		flock.cache.set.assert_called_with('futuregarage+hot+week', pickle.dumps(cache_value))
+        flock.getRedditResponse.assert_called_with(['futuregarage'], 'hot', 'week', 100)
+        flock.cache.set.assert_called_with('futuregarage+hot+week', pickle.dumps(cache_value))
 
-		flock.cache.get = mock.MagicMock(name='get', return_value=pickle.dumps(cache_value))
-		flock.cache.set = mock.MagicMock(name='set')
-		flock.getRedditResponse = mock.MagicMock(name='getRedditResponse')
+        flock.cache.get = mock.MagicMock(name='get', return_value=pickle.dumps(cache_value))
+        flock.cache.set = mock.MagicMock(name='set')
+        flock.getRedditResponse = mock.MagicMock(name='getRedditResponse')
 
-		self.app.get('/?subreddits=futuregarage', follow_redirects=True)
+        self.app.get('/?subreddits=futuregarage', follow_redirects=True)
 
-		flock.cache.get.assert_called_with('futuregarage+hot+week')
-		self.assertEqual(flock.getRedditResponse.call_count, 0)
-		self.assertEqual(flock.cache.set.call_count, 0)
+        flock.cache.get.assert_called_with('futuregarage+hot+week')
+        self.assertEqual(flock.getRedditResponse.call_count, 0)
+        self.assertEqual(flock.cache.set.call_count, 0)
 
 
 class RateLimitTestCase(FlockBaseTestCase):
     def setUp(self):
         FlockBaseTestCase.setUp(self)
-        urllib.urlopen = mock.MagicMock()
 
     def tearDown(self):
         FlockBaseTestCase.tearDown(self)
@@ -604,11 +598,11 @@ class RateLimitTestCase(FlockBaseTestCase):
 
     def test_rate_limit_calls_urlopen_when_timeout_has_passed(self):
         response = flock.rateLimitedRequest('url', 1.0)
-        urllib.urlopen.assert_called_once_with('url')
+        self.assertEqual(flock.urllib2.urlopen.call_count, 1)
 
     def test_rate_limit_returns_urlopen_reponse(self):
         urlopen_response = io.StringIO(u'{}')
-        urllib.urlopen = mock.MagicMock(return_value=urlopen_response)
+        flock.urllib2.urlopen = mock.MagicMock(return_value=urlopen_response)
         response = flock.rateLimitedRequest('url', 1.0)
         self.assertEquals(response, urlopen_response)
 
@@ -621,5 +615,5 @@ class RateLimitTestCase(FlockBaseTestCase):
         self.assertLess(delta.seconds, 5.0)
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()
 


### PR DESCRIPTION
Some third party services such as Reddit require rate limiting of some amount of seconds before any subsequent requests are made.

This can be achieved by wrapping all calls with a `rateLimitedRequest()` function which sleeps the required number of seconds before making another request (if required)

**TODO:**
- Refactor `makeRequest` to handle `urlopen` error cases
